### PR TITLE
Use required_approving_review_count=0 now that it's supported

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "~> 4.0"
+      version = "~> 4.20"
     }
   }
 }

--- a/repos.tf
+++ b/repos.tf
@@ -89,20 +89,13 @@ resource "github_branch_protection" "octodns" {
     dismiss_stale_reviews           = false
     dismissal_restrictions          = []
     require_code_owner_reviews      = false
-    # can't set this to 0 until https://github.com/integrations/terraform-provider-github/pull/971
-    # is released. when that's the case the lifecycle ignore below can go away
-    # as well
-    #required_approving_review_count = 0
+    required_approving_review_count = 0
     restrict_dismissals             = false
   }
 
   required_status_checks {
     contexts = []
     strict   = true
-  }
-
-  lifecycle {
-    ignore_changes = [required_pull_request_reviews[0].required_approving_review_count]
   }
 }
 
@@ -125,19 +118,12 @@ resource "github_branch_protection" "repo" {
     dismiss_stale_reviews           = false
     dismissal_restrictions          = []
     require_code_owner_reviews      = false
-    # can't set this to 0 until https://github.com/integrations/terraform-provider-github/pull/971
-    # is released. when that's the case the lifecycle ignore below can go away
-    # as well
-    #required_approving_review_count = 0
+    required_approving_review_count = 0
     restrict_dismissals             = false
   }
 
   required_status_checks {
     contexts = []
     strict   = true
-  }
-
-  lifecycle {
-    ignore_changes = [required_pull_request_reviews[0].required_approving_review_count]
   }
 }


### PR DESCRIPTION
Now that https://github.com/integrations/terraform-provider-github/pull/971#event-5928649291 has been merged and released we can set `required_approving_review_count = 0` so that PRs have to be up to date and passing CI to merge, but don't HARD require a review. Expectation is that everyone will behave and opt to require one on anything where it's effort is worthwhile (most things.)