### PR TITLE
Remove the octodns modules required contexts

### DIFF
--- a/repos.tf
+++ b/repos.tf
@@ -93,38 +93,7 @@ resource "github_branch_protection" "octodns" {
   }
 
   required_status_checks {
-    contexts = [
-        "ci (3.7)",
-        "ci (3.8)",
-        "ci (3.9)",
-        "ci (3.10)",
-        "ci (octodns/octodns-azure)",
-        "ci (octodns/octodns-cloudflare)",
-        "ci (octodns/octodns-constellix)",
-        "ci (octodns/octodns-ddns)",
-        "ci (octodns/octodns-digitalocean)",
-        "ci (octodns/octodns-dnsimple)",
-        "ci (octodns/octodns-dnsmadeeasy)",
-        "ci (octodns/octodns-docker)",
-        "ci (octodns/octodns-dyn)",
-        "ci (octodns/octodns-easydns)",
-        "ci (octodns/octodns-edgedns)",
-        "ci (octodns/octodns-etchosts)",
-        "ci (octodns/octodns-gandi)",
-        "ci (octodns/octodns-gcore)",
-        "ci (octodns/octodns-googlecloud)",
-        "ci (octodns/octodns-hetzner)",
-        "ci (octodns/octodns-mythicbeasts)",
-        "ci (octodns/octodns-ns1)",
-        "ci (octodns/octodns-ovh)",
-        "ci (octodns/octodns-powerdns)",
-        "ci (octodns/octodns-rackspace)",
-        "ci (octodns/octodns-route53)",
-        "ci (octodns/octodns-selectel)",
-        "ci (octodns/octodns-template)",
-        "ci (octodns/octodns-transip)",
-        "ci (octodns/octodns-ultra)",
-    ]
+    contexts = lookup(var.required_contexts, "octodns", [])
     strict   = true
   }
 }

--- a/required-contexts.tf
+++ b/required-contexts.tf
@@ -4,7 +4,7 @@
 variable "required_contexts" {
   type = map(list(string))
   default = {
-    "octodns" = ["ci (3.7)", "ci (3.8)", "ci (3.9)", "ci (3.10)", "ci (octodns/octodns-azure)", "ci (octodns/octodns-cloudflare)", "ci (octodns/octodns-constellix)", "ci (octodns/octodns-ddns)", "ci (octodns/octodns-digitalocean)", "ci (octodns/octodns-dnsimple)", "ci (octodns/octodns-dnsmadeeasy)", "ci (octodns/octodns-dyn)", "ci (octodns/octodns-easydns)", "ci (octodns/octodns-edgedns)", "ci (octodns/octodns-etchosts)", "ci (octodns/octodns-gandi)", "ci (octodns/octodns-gcore)", "ci (octodns/octodns-googlecloud)", "ci (octodns/octodns-hetzner)", "ci (octodns/octodns-mythicbeasts)", "ci (octodns/octodns-ns1)", "ci (octodns/octodns-ovh)", "ci (octodns/octodns-powerdns)", "ci (octodns/octodns-rackspace)", "ci (octodns/octodns-route53)", "ci (octodns/octodns-selectel)", "ci (octodns/octodns-transip)", "ci (octodns/octodns-ultra)"],
+    "octodns" = ["ci (3.7)", "ci (3.8)", "ci (3.9)", "ci (3.10)"],
     "octodns-azure" = ["ci (3.7)", "ci (3.8)", "ci (3.9)", "ci (3.10)", "setup-py"],
     "octodns-cloudflare" = ["ci (3.7)", "ci (3.8)", "ci (3.9)", "ci (3.10)", "setup-py"],
     "octodns-constellix" = ["ci (3.7)", "ci (3.8)", "ci (3.9)", "ci (3.10)", "setup-py"],

--- a/script/generate-required-contexts.py
+++ b/script/generate-required-contexts.py
@@ -53,13 +53,6 @@ for repo in repos:
     data = safe_load(fh.read())
     jobs = get_jobs(data)
 
-    if repo == 'octodns':
-        url = f'https://github.com/octodns/{repo}/raw/{branch}/' \
-            '.github/workflows/modules.yml'
-        fh = request.urlopen(url)
-        data = safe_load(fh.read())
-        jobs.extend(get_jobs(data))
-
     jobs = '", "'.join(jobs)
     lines.append(f'    "{repo}" = ["{jobs}"],')
 


### PR DESCRIPTION
They're going to be kicked off automatically by https://github.com/octodns/octodns/pull/890 and I think it's best not to have them "visible" and un-run up to that point. They won't be required to merge, but it seems fine to let that be socially enforced and ack'd when not "it isn't b/c xyz, ..."