### PR TITLE
Add python 3.12 to the CI version matrix

### DIFF
--- a/python-versions.tf
+++ b/python-versions.tf
@@ -1,6 +1,6 @@
 variable "python_versions_active" {
   type    = list(string)
-  default = ["3.8", "3.9", "3.10", "3.11"]
+  default = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 }
 variable "python_version_current" {
   type    = string


### PR DESCRIPTION
/cc https://github.com/octodns/octodns/pull/1081 (and its linked PRs) which enabled this by driving the version matrix off of a org-level variable
/cc https://github.com/octodns/terraformed/pull/22 which enabled managing this with terraform
/cc https://github.com/octodns/octodns-docker/pull/97