### PR TITLE
Add istr as a maintainer & reviewer

### DIFF
--- a/membership.tf
+++ b/membership.tf
@@ -14,6 +14,7 @@ resource "github_membership" "admins" {
 
 resource "github_membership" "members" {
   for_each = toset([
+    "istr",
     "parkr",
     "viranch",
   ])

--- a/teams.tf
+++ b/teams.tf
@@ -17,6 +17,7 @@ resource "github_team_membership" "review-maintainer" {
 
 resource "github_team_membership" "review-member" {
   for_each = toset([
+    "istr",
     "viranch",
   ])
 


### PR DESCRIPTION
```tf
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # github_membership.members["istr"] will be created
  + resource "github_membership" "members" {
      + downgrade_on_destroy = false
      + etag                 = (known after apply)
      + id                   = (known after apply)
      + role                 = "member"
      + username             = "istr"
    }

  # github_team_membership.review-member["istr"] will be created
  + resource "github_team_membership" "review-member" {
      + etag     = (known after apply)
      + id       = (known after apply)
      + role     = "member"
      + team_id  = "5532035"
      + username = "istr"
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```

/cc @istr
/cc @octodns/review for 👍 