### PR TITLE
Add management of AutoDNS

### DIFF
--- a/repos.tf
+++ b/repos.tf
@@ -2,6 +2,7 @@ variable "repos" {
   type = map(string)
   default = {
     # providers
+    "octodns-autodns" = "octodns Provider for AutoDNS by InternetX",
     "octodns-azure" = "Azure DNS provider for octoDNS",
     "octodns-bind" = "RFC compliant (Bind9) provider for octoDNS",
     "octodns-cloudflare" = "Cloudflare DNS provider for octoDNS",
@@ -42,6 +43,7 @@ variable "repos" {
 variable "repos_providers" {
   type = set(string)
   default = [
+    "octodns-autodns",
     "octodns-azure",
     "octodns-bind",
     "octodns-cloudflare",

--- a/teams.tf
+++ b/teams.tf
@@ -39,3 +39,30 @@ resource "github_team_repository" "review" {
   repository = each.key
   permission = "maintain"
 }
+
+# AutoDNS
+
+resource "github_team" "autodns" {
+  name        = "autodns"
+  description = "Team to group people who manage octodns-autodns"
+  privacy     = "closed"
+}
+
+resource "github_team_membership" "autodns" {
+  for_each = toset([
+    "avalor1",
+    "neubi4",
+    "xFuture603",
+    "z-bsod"
+  ])
+
+  team_id  = github_team.autodns.id
+  username = each.key
+  role     = "member"
+}
+
+resource "github_team_repository" "autodns" {
+  team_id    = github_team.autodns.id
+  repository = github_repository.repo["octodns-autodns"].id
+  permission = "maintain"
+}


### PR DESCRIPTION
Bring octodns-autodns under terraformed management. 

New team is added with the existing users added for permission management for the repo.

/cc https://github.com/octodns/octodns/issues/1231

```terraform

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

OpenTofu will perform the following actions:

  # github_branch_protection.repo["octodns-autodns"] will be created
  + resource "github_branch_protection" "repo" {
      + allows_deletions                = false
      + allows_force_pushes             = false
      + enforce_admins                  = true
      + id                              = (known after apply)
      + lock_branch                     = false
      + pattern                         = "main"
      + repository_id                   = "R_kgDOM-1aUA"
      + require_conversation_resolution = false
      + require_signed_commits          = false
      + required_linear_history         = false

      + required_pull_request_reviews {
          + dismiss_stale_reviews           = false
          + require_code_owner_reviews      = false
          + require_last_push_approval      = false
          + required_approving_review_count = 0
          + restrict_dismissals             = false
        }

      + required_status_checks {
          + contexts = [
              + "ci (3.10)",
              + "ci (3.11)",
              + "ci (3.12)",
              + "ci (3.13)",
              + "ci (3.9)",
              + "setup-py",
            ]
          + strict   = true
        }
    }

  # github_repository.repo["octodns-autodns"] will be updated in-place
  ~ resource "github_repository" "repo" {
      ~ delete_branch_on_merge      = false -> true
      ~ has_downloads               = true -> false
      ~ has_projects                = true -> false
        id                          = "octodns-autodns"
        name                        = "octodns-autodns"
        # (32 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

  # github_repository_ruleset.repo["octodns-autodns"] will be created
  + resource "github_repository_ruleset" "repo" {
      + enforcement = "active"
      + etag        = (known after apply)
      + id          = (known after apply)
      + name        = "version-tags"
      + node_id     = (known after apply)
      + repository  = "octodns-autodns"
      + ruleset_id  = (known after apply)
      + target      = "tag"

      + bypass_actors {
          + actor_id    = 1
          + actor_type  = "OrganizationAdmin"
          + bypass_mode = "always"
        }
      + bypass_actors {
          + actor_id    = 5
          + actor_type  = "RepositoryRole"
          + bypass_mode = "always"
        }

      + conditions {
          + ref_name {
              + exclude = []
              + include = [
                  + "refs/tags/v*",
                ]
            }
        }

      + rules {
          + creation                      = true
          + deletion                      = true
          + update                        = true
          + update_allows_fetch_and_merge = false
        }
    }

  # github_team.autodns will be created
  + resource "github_team" "autodns" {
      + create_default_maintainer = false
      + description               = "Team to group people who manage octodns-autodns"
      + etag                      = (known after apply)
      + id                        = (known after apply)
      + members_count             = (known after apply)
      + name                      = "autodns"
      + node_id                   = (known after apply)
      + parent_team_read_id       = (known after apply)
      + parent_team_read_slug     = (known after apply)
      + privacy                   = "closed"
      + slug                      = (known after apply)
    }

  # github_team_membership.autodns["avalor1"] will be created
  + resource "github_team_membership" "autodns" {
      + etag     = (known after apply)
      + id       = (known after apply)
      + role     = "member"
      + team_id  = (known after apply)
      + username = "avalor1"
    }

  # github_team_membership.autodns["neubi4"] will be created
  + resource "github_team_membership" "autodns" {
      + etag     = (known after apply)
      + id       = (known after apply)
      + role     = "member"
      + team_id  = (known after apply)
      + username = "neubi4"
    }

  # github_team_membership.autodns["xFuture603"] will be created
  + resource "github_team_membership" "autodns" {
      + etag     = (known after apply)
      + id       = (known after apply)
      + role     = "member"
      + team_id  = (known after apply)
      + username = "xFuture603"
    }

  # github_team_membership.autodns["z-bsod"] will be created
  + resource "github_team_membership" "autodns" {
      + etag     = (known after apply)
      + id       = (known after apply)
      + role     = "member"
      + team_id  = (known after apply)
      + username = "z-bsod"
    }

  # github_team_repository.autodns will be created
  + resource "github_team_repository" "autodns" {
      + etag       = (known after apply)
      + id         = (known after apply)
      + permission = "maintain"
      + repository = "octodns-autodns"
      + team_id    = (known after apply)
    }

  # github_team_repository.review["octodns-autodns"] will be created
  + resource "github_team_repository" "review" {
      + etag       = (known after apply)
      + id         = (known after apply)
      + permission = "maintain"
      + repository = "octodns-autodns"
      + team_id    = "5532035"
    }

Plan: 9 to add, 1 to change, 0 to destroy.
```