### PR TITLE
update autodns github team membership

### DIFF
--- a/teams.tf
+++ b/teams.tf
@@ -50,9 +50,9 @@ resource "github_team" "autodns" {
 
 resource "github_team_membership" "autodns" {
   for_each = toset([
-    "schurzi",
-    "neubi4",
     "beechesII",
+    "neubi4",
+    "schurzi",
     "z-bsod"
   ])
 

--- a/teams.tf
+++ b/teams.tf
@@ -50,9 +50,9 @@ resource "github_team" "autodns" {
 
 resource "github_team_membership" "autodns" {
   for_each = toset([
-    "avalor1",
+    "schurzi",
     "neubi4",
-    "xFuture603",
+    "beechesII",
     "z-bsod"
   ])
 


### PR DESCRIPTION
As discussed in https://github.com/octodns/octodns/issues/1231 the change of maintainers for the octodns-autodns.

* removed avalor1 and xFuture603
* added schurzi and beechesII